### PR TITLE
Feature/fix zsh keybindings: Fix to enable emacs keybindings to avoid EDITOR=vim function on zsh

### DIFF
--- a/home/.zsh/.zshrc_linux
+++ b/home/.zsh/.zshrc_linux
@@ -1,4 +1,5 @@
 # Settings of vim
 export EDITOR=vim
 alias vi=vim
+bindkey -e
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -1,3 +1,7 @@
+# For each environments
+UNAME=$(uname | tr '[A-Z]' '[a-z]')
+[ -f $HOME/.zsh/.zshrc_$UNAME ] && . $HOME/.zsh/.zshrc_$UNAME
+
 ### zsh core
 # command correction
 setopt correct
@@ -160,10 +164,6 @@ done
 if [ -e $HOME/.credentials ]; then
     source $HOME/.credentials
 fi
-
-# For each environments
-UNAME=$(uname | tr '[A-Z]' '[a-z]')
-[ -f $HOME/.zsh/.zshrc_$UNAME ] && . $HOME/.zsh/.zshrc_$UNAME
 
 # For select-word-style
 autoload -Uz select-word-style


### PR DESCRIPTION
Feature/fix zsh keybindings: Fix to enable emacs keybindings to avoid EDITOR=vim function on zsh
