### PR TITLE
Feature/fix zshrc configuration: Remove do_enter and call_precmd functions.

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -56,7 +56,6 @@ GREEN="%{${fg[green]}%}"
 
 # For show files
 chpwd() {
-    #do_enter
     ls_abbrev
 }
 
@@ -121,26 +120,6 @@ cdup() {
 }
 zle -N cdup
 bindkey '\^' cdup
-
-# Show Git information and ll as [Enter]
-function do_enter() {
-    if [ -n "$BUFFER" ]; then
-        zle accept-line
-        return 0
-    fi
-    echo
-    ls_abbrev
-    if [ "$(git rev-parse --is-inside-work-tree 2> /dev/null)" = 'true' ]; then
-        echo
-        echo -e "\e[0;33m--- git status ---\e[0m"
-        git status -sb 2> /dev/null
-    fi
-    call_precmd
-    zle reset-prompt
-    return 0
-}
-zle -N do_enter
-bindkey '^m' do_enter
 
 # For Personal libraries
 export PATH=/usr/local/bin:$PATH

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -98,25 +98,15 @@ function ls_abbrev() {
 # For autojump
 [[ -s /etc/profile.d/autojump.sh ]] && . /etc/profile.d/autojump.sh
 
-# Call precmd
-function call_precmd() {
-    local precmd_func
-    (( $+functions[precmd] )) && precmd
-    for precmd_func in $precmd_functions; do
-        $precmd_func
-    done
-}
-
 # Move to upper directory as ^
 cdup() {
     if [ -z "$BUFFER" ]; then
         echo
         cd ..
-        call_precmd
         zle reset-prompt
     else
         zle self-insert '^'
-        fi
+    fi
 }
 zle -N cdup
 bindkey '\^' cdup


### PR DESCRIPTION
Remove do_enter and call_precmd functions from .zshrc.
