### PR TITLE
Maintenance default macbook playbook (Jun 2018, Turn:1)

### DIFF
--- a/applications/Karabiner-Elements/karabiner/karabiner.json
+++ b/applications/Karabiner-Elements/karabiner/karabiner.json
@@ -1,0 +1,193 @@
+{
+    "global": {
+        "check_for_updates_on_startup": true,
+        "show_in_menu_bar": true,
+        "show_profile_name_in_menu_bar": false
+    },
+    "profiles": [
+        {
+            "complex_modifications": {
+                "parameters": {
+                    "basic.simultaneous_threshold_milliseconds": 50,
+                    "basic.to_delayed_action_delay_milliseconds": 500,
+                    "basic.to_if_alone_timeout_milliseconds": 1000,
+                    "basic.to_if_held_down_threshold_milliseconds": 500
+                },
+                "rules": [
+                    {
+                        "description": "Change spacebar to left_shift. (Post spacebar if pressed alone)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "spacebar",
+                                    "modifiers": {
+                                        "optional": [
+                                            "any"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_shift"
+                                    }
+                                ],
+                                "to_if_alone": [
+                                    {
+                                        "key_code": "spacebar"
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "devices": [
+                {
+                    "disable_built_in_keyboard_if_exists": false,
+                    "fn_function_keys": [],
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "is_pointing_device": false,
+                        "product_id": 13,
+                        "vendor_id": 1278
+                    },
+                    "ignore": false,
+                    "manipulate_caps_lock_led": false,
+                    "simple_modifications": [
+                        {
+                            "from": {
+                                "key_code": "grave_accent_and_tilde"
+                            },
+                            "to": {
+                                "key_code": "fn"
+                            }
+                        },
+                        {
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": {
+                                "key_code": "japanese_eisuu"
+                            }
+                        },
+                        {
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": {
+                                "key_code": "japanese_kana"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "fn_function_keys": [
+                {
+                    "from": {
+                        "key_code": "f1"
+                    },
+                    "to": {
+                        "consumer_key_code": "display_brightness_decrement"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f2"
+                    },
+                    "to": {
+                        "consumer_key_code": "display_brightness_increment"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f3"
+                    },
+                    "to": {
+                        "key_code": "mission_control"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f4"
+                    },
+                    "to": {
+                        "key_code": "launchpad"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f5"
+                    },
+                    "to": {
+                        "key_code": "illumination_decrement"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f6"
+                    },
+                    "to": {
+                        "key_code": "illumination_increment"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f7"
+                    },
+                    "to": {
+                        "consumer_key_code": "rewind"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f8"
+                    },
+                    "to": {
+                        "consumer_key_code": "play_or_pause"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f9"
+                    },
+                    "to": {
+                        "consumer_key_code": "fastforward"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f10"
+                    },
+                    "to": {
+                        "consumer_key_code": "mute"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f11"
+                    },
+                    "to": {
+                        "consumer_key_code": "volume_decrement"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f12"
+                    },
+                    "to": {
+                        "consumer_key_code": "volume_increment"
+                    }
+                }
+            ],
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": [],
+            "virtual_hid_keyboard": {
+                "caps_lock_delay_milliseconds": 0,
+                "country_code": 0,
+                "keyboard_type": "jis"
+            }
+        }
+    ]
+}

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   connection: local
   gather_facts: no
-  sudo: no
+  become: false
 
   pre_tasks:
     - name: 'Install gem packages'

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -171,6 +171,8 @@
         - zeromq
         - zsh
         - zsh-completions
+    - name: 'Add Java environments to jenv'
+      shell: find /Library/Java/JavaVirtualMachines -d -name "Home" -print0 | xargs -0 -I% ~/.anyenv/envs/jenv/bin/jenv add % || true
     - name: 'Install Homebrew packages: ffmpeg'
       homebrew: name=ffmpeg state=latest install_options=with-faac
     - name: 'Install Homebrew packages: ricty'

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -14,9 +14,9 @@
         - gisty
         - sigh
     - name: 'Update pip'
-      pip: name=pip executable=~/.anyenv/envs/pyenv/shims/pip2.7 state=latest
+      pip: name=pip executable=~/.anyenv/envs/pyenv/shims/pip state=latest
     - name: 'Install python packages'
-      pip: name={{ item }} executable=~/.anyenv/envs/pyenv/shims/pip2.7 extra_args="--user" state=latest
+      pip: name={{ item }} executable=~/.anyenv/envs/pyenv/shims/pip extra_args="--user" state=latest
       with_items:
         - powerline-status
         - psutil

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -28,9 +28,9 @@
     - name: 'Tap homebrew repositories'
       homebrew_tap: tap={{ item }} state=present
       with_items: 
-        - caskroom/cask
-        - caskroom/versions
-        - caskroom/homebrew-fonts
+        - homebrew/cask
+        - homebrew/cask-versions
+        - homebrew/cask-fonts
         - homebrew/versions
         - sanemat/font
         - supistar/customs

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -196,12 +196,12 @@
       command: fc-cache -vf
     - name: 'Delete temporary directory for powerline fonts'
       file: path=/tmp/fonts state=absent
-    - name: 'mkdir Karabiner dir'
-      file: path="~/Library/Application Support/Karabiner" state=directory
+    - name: 'mkdir Karabiner-Elements base dir'
+      file: path="~/.config" state=directory
     - name: 'Karabiner: Make symlink of setting files'
-      file: src={{ item }} dest="~/Library/Application Support/Karabiner/{{ item | basename }}" state=link force=yes
+      file: src={{ item }} dest="~/.config/{{ item | basename }}" state=link force=yes
       with_fileglob:
-        - ~/.homesick/repos/dotfiles/applications/Karabiner/*
+        - ~/.homesick/repos/dotfiles/applications/Karabiner-Elements/*
     - name: 'mkdir vim related directories'
       file: path={{ item }} state=directory
       notify: install neobundle

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -44,7 +44,7 @@
       with_items:
         - xquartz
         - java8
-        - 1password
+        - 1password6
         - adobe-air
         - adobe-creative-cloud
         - alfred
@@ -52,10 +52,12 @@
         - android-ndk
         - android-studio
         - appcode
-        - arduino
         - burn
+        - caffeine
+        - chromedriver
         - chromium
         - cooviewer
+        - daisydisk
         - docker
         - dropbox
         - duet
@@ -65,25 +67,30 @@
         - google-chrome
         - hhkb-professional-driver
         - intellij-idea
+        - ios-console
         - iterm2
-        - java6
-        - karabiner
+        - jetbrains-toolbox
+        - karabiner-elements
         - kensington-trackball-works
         - kindle
-        - lastfm
         - limechat
         - macvim
+        - makemkv
         - mono-mdk
-        - mono-mdk3121
         - pycharm
+        - quik
+        - sdformatter
         - skitch
         - skype
         - slack
+        - spotify
+        - sqlitebrowser
+        - steam
         - sublime-text
-        - unity463p2
         - vagrant
         - virtualbox
         - visual-studio-code
+        - vivaldi
         - vlc
         - vmware-fusion
         - webstorm
@@ -94,12 +101,15 @@
       with_items:
         - gcc
         - ant
+        - ansible
         - apktool
         - appledoc
         - autoconf
         - automake
+        - awscli
         - blueutil
-        - chromedriver
+        - boost
+        - carthage
         - cmake
         - ctags
         - curl
@@ -112,7 +122,7 @@
         - gnupg
         - go
         - gradle
-        - heroku-toolbelt
+        - heroku
         - highlight
         - highway
         - httpie
@@ -121,6 +131,7 @@
         - imagemagick
         - ino
         - ios-sim
+        - iproute2mac
         - jq
         - jsdoc3
         - lame
@@ -131,8 +142,10 @@
         - libusb-compat
         - libxml2
         - libyaml
+        - mas
         - maven
         - nkf
+        - peco
         - phantomjs
         - pkg-config
         - psutils
@@ -155,6 +168,7 @@
         - yasm
         - yuicompressor
         - z
+        - zeromq
         - zsh
         - zsh-completions
     - name: 'Install Homebrew packages: ffmpeg'

--- a/scripts/install-anyenv.sh
+++ b/scripts/install-anyenv.sh
@@ -43,3 +43,9 @@ if [ ${IS_INSTALLED_PY} -eq 0 ]; then
     git clone https://github.com/yyuu/pyenv-update.git ${PYENV_PLUGINS_ROOT}/pyenv-update
 fi
 
+IS_INSTALLED_J=$(anyenv version | grep jenv | wc -l | xargs echo)
+if [ ${IS_INSTALLED_J} -eq 0 ]; then
+    anyenv install -f jenv
+    ${SHELL} -lc "jenv rehash"
+fi
+

--- a/scripts/install-anyenv.sh
+++ b/scripts/install-anyenv.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-RB_VER=2.2.2
-ND_VER=v0.10.36
-PY_VER=2.7.10
+RB_VER=2.5.1
+ND_VER=v8.11.3
+PY_VER=3.6.5
 
 ANYENV_ROOT=${HOME}/.anyenv
 PYENV_PLUGINS_ROOT=${ANYENV_ROOT}/envs/pyenv/plugins


### PR DESCRIPTION
Maintenance default macbook playbook (Jun 2018, Turn:1)
- Add/Remove packages
- Fix playbook definitions
- Support jenv
- Add Karabiner-Elements support