### PR TITLE
Maintenance dotfiles (Jan 2021, Turn:3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ home/.vim/.netrwhist
 
 # Homesick
 automatic_backups/
+
+# Local
+home/.gitconfig.local

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ home/.vim/.netrwhist
 # Retry file
 *.retry
 
+# Homesick
+automatic_backups/

--- a/home/.config/karabiner/assets/complex_modifications/karabiner-hhkb-professional-jp.json
+++ b/home/.config/karabiner/assets/complex_modifications/karabiner-hhkb-professional-jp.json
@@ -1,0 +1,751 @@
+{
+  "title": "HHKB Professional JP specific settings",
+  "rules": [
+    {
+      "description": "Remap ANSI Keyboard to JIS (For HHKB Professional JP)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "0",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "equal_sign"
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "international3"
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "open_bracket"
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "close_bracket"
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "quote"
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "non_us_pound"
+          },
+          "to": [
+            {
+              "key_code": "close_bracket"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "non_us_pound",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "international1"
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change space bar to left_shift - SandS (For HHKB Professional JP)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_shift"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change some keybindings for Ryuji (For HHKB Professional JP)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "grave_accent_and_tilde"
+          },
+          "to": [
+            {
+              "key_code": "fn"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "international5"
+          },
+          "to": [
+            {
+              "key_code": "left_alt"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "left_option"
+          },
+          "to": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1278,
+                  "product_id": 13
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "right_option"
+          },
+          "to": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/home/.config/karabiner/karabiner.json
+++ b/home/.config/karabiner/karabiner.json
@@ -1,0 +1,227 @@
+{
+    "global": {
+        "check_for_updates_on_startup": true,
+        "show_in_menu_bar": true,
+        "show_profile_name_in_menu_bar": false
+    },
+    "profiles": [
+        {
+            "complex_modifications": {
+                "parameters": {
+                    "basic.simultaneous_threshold_milliseconds": 50,
+                    "basic.to_delayed_action_delay_milliseconds": 500,
+                    "basic.to_if_alone_timeout_milliseconds": 1000,
+                    "basic.to_if_held_down_threshold_milliseconds": 500,
+                    "mouse_motion_to_scroll.speed": 100
+                },
+                "rules": [
+                    {
+                        "description": "Change spacebar to left_shift. (Post spacebar if pressed alone)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "spacebar",
+                                    "modifiers": {
+                                        "optional": [
+                                            "any"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_shift"
+                                    }
+                                ],
+                                "to_if_alone": [
+                                    {
+                                        "key_code": "spacebar"
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "devices": [
+                {
+                    "disable_built_in_keyboard_if_exists": true,
+                    "fn_function_keys": [],
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "is_pointing_device": false,
+                        "product_id": 13,
+                        "vendor_id": 1278
+                    },
+                    "ignore": false,
+                    "manipulate_caps_lock_led": false,
+                    "simple_modifications": [
+                        {
+                            "from": {
+                                "key_code": "grave_accent_and_tilde"
+                            },
+                            "to": {
+                                "key_code": "caps_lock"
+                            }
+                        },
+                        {
+                            "from": {
+                                "key_code": "international2"
+                            },
+                            "to": {
+                                "key_code": "japanese_kana"
+                            }
+                        },
+                        {
+                            "from": {
+                                "key_code": "international5"
+                            },
+                            "to": {
+                                "key_code": "left_alt"
+                            }
+                        },
+                        {
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": {
+                                "key_code": "japanese_eisuu"
+                            }
+                        },
+                        {
+                            "from": {
+                                "key_code": "right_option"
+                            },
+                            "to": {
+                                "key_code": "japanese_kana"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "disable_built_in_keyboard_if_exists": false,
+                    "fn_function_keys": [],
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "is_pointing_device": false,
+                        "product_id": 627,
+                        "vendor_id": 1452
+                    },
+                    "ignore": false,
+                    "manipulate_caps_lock_led": true,
+                    "simple_modifications": []
+                }
+            ],
+            "fn_function_keys": [
+                {
+                    "from": {
+                        "key_code": "f1"
+                    },
+                    "to": {
+                        "consumer_key_code": "display_brightness_decrement"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f2"
+                    },
+                    "to": {
+                        "consumer_key_code": "display_brightness_increment"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f3"
+                    },
+                    "to": {
+                        "key_code": "mission_control"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f4"
+                    },
+                    "to": {
+                        "key_code": "launchpad"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f5"
+                    },
+                    "to": {
+                        "key_code": "illumination_decrement"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f6"
+                    },
+                    "to": {
+                        "key_code": "illumination_increment"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f7"
+                    },
+                    "to": {
+                        "consumer_key_code": "rewind"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f8"
+                    },
+                    "to": {
+                        "consumer_key_code": "play_or_pause"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f9"
+                    },
+                    "to": {
+                        "consumer_key_code": "fastforward"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f10"
+                    },
+                    "to": {
+                        "consumer_key_code": "mute"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f11"
+                    },
+                    "to": {
+                        "consumer_key_code": "volume_decrement"
+                    }
+                },
+                {
+                    "from": {
+                        "key_code": "f12"
+                    },
+                    "to": {
+                        "consumer_key_code": "volume_increment"
+                    }
+                }
+            ],
+            "name": "Default profile",
+            "parameters": {
+                "delay_milliseconds_before_open_device": 1000
+            },
+            "selected": true,
+            "simple_modifications": [],
+            "virtual_hid_keyboard": {
+                "caps_lock_delay_milliseconds": 0,
+                "country_code": 0,
+                "keyboard_type": "jis",
+                "mouse_key_xy_scale": 100
+            }
+        }
+    ]
+}

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -1,7 +1,5 @@
 [include]
     path = .gitconfig.local
-[credential]
-    helper = cache --timeout=3600
 [core]
     editor = vim -c \"set fenc=utf-8\"
     pager = less -R
@@ -22,3 +20,5 @@
 	smudge = git-lfs smudge -- %f
 	process = git-lfs filter-process
 	required = true
+[pull]
+	rebase = false

--- a/home/.tmux/conf/powerline.conf
+++ b/home/.tmux/conf/powerline.conf
@@ -1,3 +1,3 @@
-POWERLINE_LIB=$HOME/.local/lib/python2.7/site-packages/powerline
+POWERLINE_LIB=$HOME/.local/lib/python3.9/site-packages/powerline
 source $POWERLINE_LIB/bindings/tmux/powerline.conf
 source $POWERLINE_LIB/bindings/tmux/powerline_tmux_1.9_plus.conf

--- a/home/.zsh/.zshrc_darwin
+++ b/home/.zsh/.zshrc_darwin
@@ -1,5 +1,5 @@
 ### Aliases
-alias rm='rmtrash'
+alias rm='trash'
 alias rrm='/bin/rm'
 
 # For mosh

--- a/playbooks/default/macbook.yml
+++ b/playbooks/default/macbook.yml
@@ -5,6 +5,9 @@
   become: false
 
   pre_tasks:
+    - name: 'Check current architecture'
+      shell: uname -m
+      register: architecture
     - name: 'Install gem packages'
       gem: name={{ item }} executable=~/.anyenv/envs/rbenv/shims/gem user_install=False
       with_items:
@@ -21,7 +24,7 @@
         - powerline-status
         - psutil
     - name: 'Install node packages'
-      npm: name={{ item }} executable=~/.anyenv/envs/ndenv/shims/npm global=yes state=latest
+      npm: name={{ item }} executable=~/.anyenv/envs/nodenv/shims/npm global=yes state=latest
       with_items:
         - js-beautify
         - git-fire
@@ -31,9 +34,8 @@
         - homebrew/cask
         - homebrew/cask-versions
         - homebrew/cask-fonts
-        - sanemat/font
+        - homebrew-ffmpeg/ffmpeg
         - supistar/customs
-        - tkengo/highway
     - name: 'Update Homebrew'
       command: brew update
 
@@ -42,40 +44,38 @@
       homebrew_cask: name={{ item }}
       with_items:
         - xquartz
-        - java8
-        - 1password6
-        - adobe-air
+        - 1password
         - adobe-creative-cloud
         - alfred
         - android-sdk
+        - android-platform-tools
         - android-ndk
         - android-studio
         - appcode
+        - atok
+        - autodesk-fusion360
         - burn
-        - caffeine
         - chromedriver
         - chromium
-        - cooviewer
         - daisydisk
         - docker
         - dropbox
-        - duet
         - firefox
-        - font-m-plus
+        - font-mplus
         - font-terminus
+        - goland
         - google-chrome
+        - hex-fiend
         - hhkb-professional-driver
         - intellij-idea
         - ios-console
         - iterm2
         - jetbrains-toolbox
         - karabiner-elements
-        - kensington-trackball-works
+        - homebrew/cask-drivers/kensington-trackball-works
         - kindle
-        - limechat
-        - macvim
         - makemkv
-        - mono-mdk
+        - osxfuse
         - pycharm
         - quik
         - sdformatter
@@ -83,9 +83,9 @@
         - skype
         - slack
         - spotify
-        - sqlitebrowser
         - steam
         - sublime-text
+        - unity-hub
         - vagrant
         - virtualbox
         - visual-studio-code
@@ -93,97 +93,108 @@
         - vlc
         - vmware-fusion
         - webstorm
-        - xamarin-studio
         - xmind
+        - zoomus
+    - name: 'Install Homebrew packages (x86_64)'
+      when: architecture.stdout == "x86_64"
+      homebrew:
+        state: latest
+        name:
+          - apktool
+          - appledoc
+          - arduino-cli
+          - circleci
+          - mas
+          - packer
+          - sshfs
+          - terraform
+          - terraformer
+          - wine
+          - winetricks
+          - xctool
     - name: 'Install Homebrew packages'
-      homebrew: name={{ item }} state=latest
-      with_items:
-        - gcc
-        - ant
-        - ansible
-        - apktool
-        - appledoc
-        - autoconf
-        - automake
-        - awscli
-        - blueutil
-        - boost
-        - carthage
-        - cmake
-        - ctags
-        - curl
-        - doxygen
-        - expat
-        - faac
-        - fswatch
-        - git
-        - git-flow
-        - gnupg
-        - go
-        - gradle
-        - heroku
-        - highlight
-        - highway
-        - httpie
-        - hub
-        - icu4c
-        - imagemagick
-        - ino
-        - ios-sim
-        - iproute2mac
-        - jq
-        - jsdoc3
-        - lame
-        - libevent
-        - libpng
-        - libtool
-        - libusb
-        - libusb-compat
-        - libxml2
-        - libyaml
-        - mas
-        - maven
-        - nkf
-        - peco
-        - phantomjs
-        - pkg-config
-        - psutils
-        - reattach-to-user-namespace
-        - redis
-        - rmtrash
-        - source-highlight
-        - sqlite
-        - swig
-        - tig
-        - tmux
-        - tree
-        - watch
-        - wget
-        - wine
-        - winetricks
-        - x264
-        - xctool
-        - xvid
-        - yasm
-        - yuicompressor
-        - z
-        - zeromq
-        - zsh
-        - zsh-completions
+      homebrew:
+        state: latest
+        name:
+          - gcc
+          - adns
+          - ag
+          - ant
+          - ansible
+          - autoconf
+          - automake
+          - awscli
+          - blueutil
+          - boost
+          - carthage
+          - cmake
+          - coreutils
+          - ctags
+          - curl
+          - doxygen
+          - expat
+          - faac
+          - fswatch
+          - git
+          - git-flow
+          - git-lfs
+          - glib
+          - gnu-sed
+          - gnupg
+          - go
+          - gradle
+          - highlight
+          - httpie
+          - hub
+          - icu4c
+          - imagemagick
+          - ios-sim
+          - iproute2mac
+          - jq
+          - jsdoc3
+          - lame
+          - libevent
+          - libpng
+          - libtool
+          - libusb
+          - libusb-compat
+          - libxml2
+          - libyaml
+          - maven
+          - macos-trash
+          - nkf
+          - peco
+          - pkg-config
+          - psutils
+          - reattach-to-user-namespace
+          - redis
+          - rename
+          - source-highlight
+          - sqlite
+          - swig
+          - tig
+          - tmux
+          - tree
+          - watch
+          - wget
+          - x264
+          - xvid
+          - yasm
+          - yuicompressor
+          - z
+          - zeromq
+          - zsh
+          - zsh-completions
     - name: 'Add Java environments to jenv'
       shell: find /Library/Java/JavaVirtualMachines -d -name "Home" -print0 | xargs -0 -I% ~/.anyenv/envs/jenv/bin/jenv add % || true
-    - name: 'Install Homebrew packages: ffmpeg'
-      homebrew: name=ffmpeg state=latest install_options=with-faac
-    - name: 'Install Homebrew packages: ricty'
-      homebrew: name=ricty state=latest install_options=powerline,vim-powerline
+    - name: 'Install Homebrew packages: homebrew-ffmpeg/ffmpeg/ffmpeg'
+      homebrew: name=homebrew-ffmpeg/ffmpeg/ffmpeg state=latest install_options=with-fdk-aac
     - name: 'Clone dotfiles under home dir'
       command: homesick clone supistar/dotfiles
     - name: 'Pull homesick dotfiles'
       command: homesick pull dotfiles
     - name: 'Make symlinks to under home dir'
       command: homesick symlink dotfiles --force
-    - name: 'Copy Ricty fonts'
-      shell: cp -f /usr/local/opt/ricty/share/fonts/Ricty*.ttf ~/Library/Fonts/
     - name: 'Clone powerline fonts'
       unarchive:
         src: https://github.com/powerline/fonts/archive/master.zip

--- a/scripts/distributions/Mac/init.sh
+++ b/scripts/distributions/Mac/init.sh
@@ -4,7 +4,8 @@
 sudo xcodebuild -license
 
 # Install homebrew
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+yes | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> ~/.zprofile
 brew doctor
 
 # Update homebrew
@@ -18,6 +19,8 @@ ansible-galaxy install hnakamur.homebrew-cask-packages
 
 # Set anyenv path
 sh ./scripts/set-anyenv-path.sh bash_profile
+# Install required packages for anyenv
+brew install zlib bzip2 openssl
 # Reload profile
 source ~/.bash_profile
 # Install anyenv

--- a/scripts/install-anyenv.sh
+++ b/scripts/install-anyenv.sh
@@ -2,7 +2,7 @@
 
 RB_VER=2.7.2
 ND_VER=14.15.4
-PY_VER=3.8.7
+PY_VER=3.9.1
 
 ANYENV_ROOT=${HOME}/.anyenv
 PYENV_PLUGINS_ROOT=${ANYENV_ROOT}/envs/pyenv/plugins
@@ -17,31 +17,32 @@ export PATH="$HOME/.anyenv/bin:$PATH"
 
 # Install
 ~/.anyenv/bin/anyenv init
-~/.anyenv/bin/anyenv install --init
+~/.anyenv/bin/anyenv install --init --force
 
 IS_INSTALLED_RB=$(rbenv version | grep ${RB_VER} | wc -l | xargs echo)
-if [ ${IS_INSTALLED_RB} -eq 0 ]; then
+if [ ${IS_INSTALLED_RB} -le 1 ]; then
     anyenv install -f rbenv
     ${SHELL} -lc "rbenv install -f ${RB_VER} && rbenv global ${RB_VER} && rbenv rehash"
 fi
 
 IS_INSTALLED_ND=$(nodenv version | grep ${ND_VER} | wc -l | xargs echo)
-if [ ${IS_INSTALLED_ND} -eq 0 ]; then
+if [ ${IS_INSTALLED_ND} -le 1 ]; then
     anyenv install -f nodenv
     ${SHELL} -lc "nodenv install -f ${ND_VER} && nodenv global ${ND_VER} && nodenv rehash"
 fi
 
 IS_INSTALLED_PY=$(pyenv version | grep ${PY_VER} | wc -l | xargs echo)
-if [ ${IS_INSTALLED_PY} -eq 0 ]; then
+if [ ${IS_INSTALLED_PY} -le 1 ]; then
     anyenv install -f pyenv
     if test "${SYS_NAME}" == "Darwin"; then
-        PYENV_FLAGS=$(echo CFLAGS="-I$(brew --prefix openssl)/include" LDFLAGS="-L$(brew --prefix openssl)/lib")
+        PYENV_FLAGS=$(echo CFLAGS=\"-I$(brew --prefix openssl)/include\" LDFLAGS=\"-L$(brew --prefix openssl)/lib -L$(brew --prefix zlib)/lib -L$(brew --prefix bzip2)/lib\")
+	echo "Additional pyenv flags: ${PYENV_FLAGS}"
     fi
     ${SHELL} -lc "${PYENV_FLAGS} pyenv install -f ${PY_VER} && pyenv global ${PY_VER} && pyenv rehash"
 
     # Install plugins
-    git clone https://github.com/yyuu/pyenv-virtualenv.git ${PYENV_PLUGINS_ROOT}/pyenv-virtualenv
-    git clone https://github.com/yyuu/pyenv-update.git ${PYENV_PLUGINS_ROOT}/pyenv-update
+    git clone https://github.com/pyenv/pyenv-virtualenv.git ${PYENV_PLUGINS_ROOT}/pyenv-virtualenv
+    git clone https://github.com/pyenv/pyenv-update.git ${PYENV_PLUGINS_ROOT}/pyenv-update
 fi
 
 IS_INSTALLED_J=$(anyenv version | grep jenv | wc -l | xargs echo)


### PR DESCRIPTION
Maintenance dotfiles (Jan 2021, Turn:3)

- Support MacOSX M1 architecture (homebrew, playbook and so on).
- Add Karabiner-Elements configurations.
- Fix some configurations.